### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Update opentelemetry-stackdriver requirement from 0.26 to 0.27
+
+### Other
+
+- switch to release-plz
+
+## [0.1.1]
+
+### Other
+
+- remove lockfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_metadata_resolver"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "Helper utility to identify the Monitored Resource inside Google Cloud Platform"
 repository = "https://github.com/valkum/gcp_metadata_resolver"


### PR DESCRIPTION
The update of opentelemetry-stackdriver should be a minor release.